### PR TITLE
 Fix for address checksum validation and backend error propagation

### DIFF
--- a/src/frontend/src/components/SendFile.tsx
+++ b/src/frontend/src/components/SendFile.tsx
@@ -5,6 +5,7 @@ import useTransferCreate from "../transfer/hooks/useTransferCreate";
 import { useToast } from "@/hooks/use-toast";
 import { LoaderCircle } from "lucide-react";
 import { queryClient } from "@/main";
+import { isAddress } from "viem";
 
 export default function SendFile() {
   const { actor } = useActor();
@@ -24,6 +25,24 @@ export default function SendFile() {
 
     setSaving(true);
     try {
+      if (!isAddress(recipientAddress)) {
+        toast({
+          variant: "destructive",
+          description:
+            "Invalid Ethereum address format. Please check and try again.",
+        });
+        return;
+      }
+
+      if (!isAddress(recipientAddress, { strict: true })) {
+        toast({
+          variant: "destructive",
+          description:
+            "Address must be in proper checksum format (mixed case).",
+        });
+        return;
+      }
+
       await createTransfer({ recipientAddress, file });
       toast({ description: "File sent successfully!" });
       void queryClient.invalidateQueries({ queryKey: ["transfer_list"] });

--- a/src/frontend/src/transfer/hooks/useTransferCreate.tsx
+++ b/src/frontend/src/transfer/hooks/useTransferCreate.tsx
@@ -40,7 +40,11 @@ export default function useTransferCreate() {
         filename: file.name,
         data: encryptedFile.serialize(),
       };
-      return backend.transfer_create(request);
+      const result = await backend.transfer_create(request);
+      if ("Err" in result) {
+        throw new Error(result.Err);
+      }
+      return result.Ok;
     },
   });
 }


### PR DESCRIPTION
Thanks Kristofer for your beautiful demo app!

Some friends and I are trying to implement your `base send` idea from X for the WCHL. We are starting from this demo app. 

While testing it, I found a little bug: when sending a file to a lowercased address we get a positive answer from the UI but the file is not saved. It's not some strange edge case it will never happen because MetaMask oddly gives the Ethereum address sometimes in checksummed format, and sometimes in lowercase format — for example, in the account details screen (of the browser extension).


**How to reproduce the bug**

Copy-paste a lowercase address into the address field, you will get a success message from the UI, but the file is not being uploaded. Switching to the receiver address, the file does not show up.

**Reason**

The lowercase address is passed to the backend through:

```ts
await createTransfer({ recipientAddress, file });
```

in `SendFile.tsx`, which uses the `useTransferCreate` hook from `useTransferCreate.tsx`, which in turn calls:

```ts
backend.transfer_create(request);
```

On the backend, in `src/backend/src/transfer/controller/transfer_create.rs`, line 26 returns an error:

```rust
let to = Address::parse_checksummed(args.to, None).map_err(|e| e.to_string())?;
```

The problem is that on the frontend this error becomes a simple JS object `{ Err: ... }`, which will **not** be caught by the `try/catch` block around `await createTransfer(...)`.

**Proposed solution**

I decided **not** to transform the address into a checksummed format in the frontend, because the purpose of the checksum format is to detect possible errors — and auto-transforming would invalidate that purpose.

Instead, I added two checks on `recipientAddress`:

* whether it is a valid address
* whether it is checksummed

If not, the function returns early and a toast is triggered.

To make it future-proof (in case a lowercase address still reaches the backend, falls it will be changed), I added proper error handling in the `useTransferCreate` hook, so that it **throws** an error in case the backend returns an `{ Err: ... }`.

Cheers!
